### PR TITLE
Plotlyjs for graphs

### DIFF
--- a/django_app/templates/sim_sp.html
+++ b/django_app/templates/sim_sp.html
@@ -4,6 +4,7 @@
     {% load static %}
     <meta charset="UTF-8">
     <link rel="stylesheet" href="{% static 'style.css' %}">
+
     <title>Parameter Selection</title>
 </head>
 
@@ -95,16 +96,11 @@
         <div id="id_chart_tsoc_p"></div>
         <div id="id_chart_tsoc_n"></div>
         <div id="id_chart_ttemp"></div>
-        <canvas id="id_chart_tV" height="150" width="150"></canvas>
-        <canvas id="id_chart_tsoc_p" height="150" width="150"></canvas>
-        <canvas id="id_chart_tsoc_n" height="150" width="150"></canvas>
-        <canvas id="id_chart_ttemp" height="150" width="150"></canvas>
     </div>
 
 
 
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" charset="utf-8"></script>
     <script src="{% static 'index.js' %}"></script>
     <script>
@@ -114,10 +110,10 @@
         var socNArray = {{ soc_n_sim }};
         var tempArray = {{ temp_sim }};
         let yaxis_data =
-            [[vArray,"id_chart_tV"],
-                [socPArray,"id_chart_tsoc_p"],
-                [socNArray,"id_chart_tsoc_n"],
-                [tempArray, "id_chart_ttemp"]]
+            [[vArray,"id_chart_tV", "Potential [V]"],
+                [socPArray,"id_chart_tsoc_p", "SOC_p"],
+                [socNArray,"id_chart_tsoc_n", "SOC_n"],
+                [tempArray, "id_chart_ttemp", "Temperature [°C]"]]
         for ( let i = 0 ; i < tArray.length ; i++ ) {
             var traces = [{
                 type: 'scatter',
@@ -128,77 +124,48 @@
                 line: {
                   color: 'rgb(219, 64, 82)',
                   width: 3
-                }
+                },
             }];
             var layout = {
                 width: 500,
-                height: 500,
+                length: 500,
                 plot_bgcolor:'rgb(0, 0, 0, 0)',
                 paper_bgcolor:'rgb(0, 0, 0, 0)',
+                margin: {
+                    t: 25, //top margin
+                    l: 45, //left margin
+                    r: 45, //right margin,
+                    b: 45 //bottom margin}
+                    },
+                yaxis: {
+                    autorange: true,
+                    showgrid: true,
+                    showline: true,
+                    mirror: 'ticks',
+                    gridwidth: 1,
+                    tickfont: {
+                        size: 14
+                    },
+                    title: {
+                        text: yaxis_data[i][2]
+                    },
+                },
+                xaxis: {
+                    tickfont: {
+                        size: 14
+                    },
+                    title: {
+                        text: "Time [s]",
+                        font: {
+                            size: 14
+                        }
+                    },
+                    showline: true,
+                    mirror: 'ticks',
+                }
             };
             Plotly.newPlot(yaxis_data[i][1], traces, layout);
         }
-        /*trace1 = {
-        type: 'scatter',
-        x: {{ t_sim }},
-        y: {{ soc_p_sim }},
-        mode: 'lines',
-        name: 'Red',
-        line: {
-          color: 'rgb(219, 64, 82)',
-          width: 3
-          }
-        };
-
-        trace2 = {
-            type: 'scatter',
-            x: {{ t_sim }},
-            y: {{ soc_n_sim }},
-          mode: 'lines',
-          name: 'Blue',
-          line: {
-            color: 'rgb(55, 128, 191)',
-            width: 1
-          }
-        };
-
-        var layout = {
-          width: 500,
-          height: 500
-        };
-
-        var data = [trace1, trace2];
-
-        Plotly.newPlot('myDiv', data, layout);
-
-
-        //////////////////////////////////////////
-
-
-        tArray = tArray.map(function (each_element) {return Number(each_element.toFixed(0))});
-
-        function LinePlotConfig(xArray, yArray, plotLabel) {
-            return {type: 'line',
-                data: {labels: xArray,
-                    datasets: [{label: plotLabel, data: yArray, borderWidth: 1, backgroundColor: 'black'}]},
-                options: {scales: {y: {beginAtZero: false}}}};
-        }
-
-        const ctxTV = document.getElementById('id_chart_tV');
-        const configTV = LinePlotConfig(tArray, vArray, 'Terminal Voltage [V]');
-        var chartObjTV = new Chart(ctxTV, configTV);
-
-        const ctxSOCp = document.getElementById('id_chart_tsoc_p');
-        const configSOCp = LinePlotConfig(tArray, socPArray, 'SOC_p')
-        var chartObjSOCp = new Chart(ctxSOCp, configSOCp);
-
-        const ctxSOCn = document.getElementById('id_chart_tsoc_n');
-        const configSOCn = LinePlotConfig(tArray, socNArray, 'SOC_n')
-        var chartObjSOCn = new Chart(ctxSOCn, configSOCn);
-
-        const ctxttemp = document.getElementById('id_chart_ttemp');
-        const configtemp = LinePlotConfig(tArray, tempArray, 'Temp [C]')
-        var chartObjttemp = new Chart(ctxttemp, configtemp);*/
     </script>
 </body>
 </html>

--- a/django_app/templates/sim_sp.html
+++ b/django_app/templates/sim_sp.html
@@ -91,6 +91,10 @@
 
     <!-- Div containing the t and V plot -->
     <div class="plots">
+        <div id="id_chart_tV"></div>
+        <div id="id_chart_tsoc_p"></div>
+        <div id="id_chart_tsoc_n"></div>
+        <div id="id_chart_ttemp"></div>
         <canvas id="id_chart_tV" height="150" width="150"></canvas>
         <canvas id="id_chart_tsoc_p" height="150" width="150"></canvas>
         <canvas id="id_chart_tsoc_n" height="150" width="150"></canvas>
@@ -101,6 +105,7 @@
 
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" charset="utf-8"></script>
     <script src="{% static 'index.js' %}"></script>
     <script>
         var tArray = {{ t_sim }};
@@ -108,6 +113,67 @@
         var socPArray = {{ soc_p_sim }};
         var socNArray = {{ soc_n_sim }};
         var tempArray = {{ temp_sim }};
+        let yaxis_data =
+            [[vArray,"id_chart_tV"],
+                [socPArray,"id_chart_tsoc_p"],
+                [socNArray,"id_chart_tsoc_n"],
+                [tempArray, "id_chart_ttemp"]]
+        for ( let i = 0 ; i < tArray.length ; i++ ) {
+            var traces = [{
+                type: 'scatter',
+                x: tArray,
+                y: yaxis_data[i][0],
+                mode: 'lines',
+                name: 'Red',
+                line: {
+                  color: 'rgb(219, 64, 82)',
+                  width: 3
+                }
+            }];
+            var layout = {
+                width: 500,
+                height: 500,
+                plot_bgcolor:'rgb(0, 0, 0, 0)',
+                paper_bgcolor:'rgb(0, 0, 0, 0)',
+            };
+            Plotly.newPlot(yaxis_data[i][1], traces, layout);
+        }
+        /*trace1 = {
+        type: 'scatter',
+        x: {{ t_sim }},
+        y: {{ soc_p_sim }},
+        mode: 'lines',
+        name: 'Red',
+        line: {
+          color: 'rgb(219, 64, 82)',
+          width: 3
+          }
+        };
+
+        trace2 = {
+            type: 'scatter',
+            x: {{ t_sim }},
+            y: {{ soc_n_sim }},
+          mode: 'lines',
+          name: 'Blue',
+          line: {
+            color: 'rgb(55, 128, 191)',
+            width: 1
+          }
+        };
+
+        var layout = {
+          width: 500,
+          height: 500
+        };
+
+        var data = [trace1, trace2];
+
+        Plotly.newPlot('myDiv', data, layout);
+
+
+        //////////////////////////////////////////
+
 
         tArray = tArray.map(function (each_element) {return Number(each_element.toFixed(0))});
 
@@ -132,7 +198,7 @@
 
         const ctxttemp = document.getElementById('id_chart_ttemp');
         const configtemp = LinePlotConfig(tArray, tempArray, 'Temp [C]')
-        var chartObjttemp = new Chart(ctxttemp, configtemp);
+        var chartObjttemp = new Chart(ctxttemp, configtemp);*/
     </script>
 </body>
 </html>

--- a/django_app/urls.py
+++ b/django_app/urls.py
@@ -4,5 +4,5 @@ from . import views
 
 urlpatterns: list = [
     path(route="", view=views.index, name='index'),
-    path(route="result/", view=views.result, name='result')
+    #path(route="result/", view=views.result, name='result')
 ]


### PR DESCRIPTION
Use plotlyjs to replace chartjs for graphing things due to the former providing more fine-tuning options to graph presentation.
All legacy code for chartjs is removed.